### PR TITLE
feat: add flow plugin based on user's package.json

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,4 @@
 module.exports = {
   collectCoverageFrom: ['packages/**/*.js'],
+  testPathIgnorePatterns: ['/.cache/']
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,4 @@
 module.exports = {
   collectCoverageFrom: ['packages/**/*.js'],
-  testPathIgnorePatterns: ['/.cache/']
+  testPathIgnorePatterns: ['/.cache/'],
 };

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "site"
   ],
   "scripts": {
-    "lint": "eslint packages",
+    "lint": "eslint packages --ignore-path .gitignore",
     "lint-staged": "lint-staged",
     "prettier": "is-ci prettier:check prettier:format",
     "prettier:check": "prettier --check \"**/*.{js,md}\" --ignore-path .gitignore",

--- a/packages/gatsby-theme-dslemay-core/README.md
+++ b/packages/gatsby-theme-dslemay-core/README.md
@@ -54,3 +54,11 @@ Analytics is off by default. The configuration accepts a string or an object to 
 
 - String: Must be your Google Analytics tracking id. Sets the `anonymize` option to true.
 - Object: Pass in the same options listed in the plugin docs. Anonymize is defaulted to true, but can be overriden by your configuration object.
+
+## Conditionally added plugins
+
+Gatsby has a number of plugins which may be added dependening on other dependencies you use in your project. For example `gatsby-plugin-flow` will add the necessary Babel config to strip out flow types, and `gatsby-plugin-emotion` will handle the Babel presets to use Emotion's css prop without needing to use the JSX pragma at the top of each file. The following plugins will be added automatically if you have the corresponding dependency installed.
+
+| Dependency | Gatsby Plugin        |
+| ---------- | -------------------- |
+| `flow-bin` | `gatsby-plugin-flow` |

--- a/packages/gatsby-theme-dslemay-core/__tests__/gatsby-config.test.js
+++ b/packages/gatsby-theme-dslemay-core/__tests__/gatsby-config.test.js
@@ -1,5 +1,14 @@
 const gatsbyConfig = require('../gatsby-config');
-const findPluginObject = require('../plugin-testing');
+const { findPluginString, findPluginObject } = require('../plugin-testing');
+const {
+  hasDependencies: hasDependenciesMock,
+  hasDevDependencies: hasDevDependenciesMock,
+} = require('../utils');
+
+jest.mock('../utils', () => ({
+  hasDependencies: jest.fn(),
+  hasDevDependencies: jest.fn(),
+}));
 
 describe('Gatsby Plugin Sitemap', () => {
   it('the sitemap option defaults to true and provides the sitemap plugin', () => {
@@ -63,5 +72,28 @@ describe('Gatsby Plugin Google Analytics', () => {
     const plugin = findAnalytics(config);
 
     expect(plugin.options).toEqual(overrideSettings);
+  });
+});
+
+describe('Gatsby Plugin Flow', () => {
+  const hasFlow = findPluginString('gatsby-plugin-flow');
+
+  it('adds the plugin if flow-bin is in the package dependencies', () => {
+    hasDependenciesMock.mockImplementationOnce(() => true);
+    const config = gatsbyConfig();
+    expect(hasFlow(config)).toBe(true);
+  });
+
+  it('adds the plugin if flow-bin is in the package devDependencies', () => {
+    hasDevDependenciesMock.mockImplementationOnce(() => true);
+    const config = gatsbyConfig();
+    expect(hasFlow(config)).toBe(true);
+  });
+
+  it('does not add the plugin if flow-bin is not in the package devDependencies or dependencies', () => {
+    hasDependenciesMock.mockImplementationOnce(() => false);
+    hasDevDependenciesMock.mockImplementationOnce(() => false);
+    const config = gatsbyConfig();
+    expect(hasFlow(config)).toBe(false);
   });
 });

--- a/packages/gatsby-theme-dslemay-core/__tests__/plugin-testing.test.js
+++ b/packages/gatsby-theme-dslemay-core/__tests__/plugin-testing.test.js
@@ -1,4 +1,4 @@
-const findPluginObject = require('../plugin-testing');
+const { findPluginObject } = require('../plugin-testing');
 
 describe('Find Plugin Object utility', () => {
   const PLUGIN_NAME = 'sample-plugin';

--- a/packages/gatsby-theme-dslemay-core/__tests__/utils.test.js
+++ b/packages/gatsby-theme-dslemay-core/__tests__/utils.test.js
@@ -1,0 +1,29 @@
+/* eslint-disable global-require */
+jest.mock('read-pkg-up', () => ({
+  sync: jest.fn(() => ({ pkg: {} })),
+}));
+
+let readPkgUpSyncMock;
+
+beforeEach(() => {
+  jest.resetModules();
+  readPkgUpSyncMock = require('read-pkg-up').sync;
+});
+
+const mockPkg = (pkg = {}) => {
+  readPkgUpSyncMock.mockImplementationOnce(() => ({ pkg }));
+};
+
+describe('Package.json utils', () => {
+  it('hasDevDependencies returns true if a package is in devDependencies', () => {
+    mockPkg({ devDependencies: { 'flow-bin': '0.92.0' } });
+    expect(require('../utils').hasDevDependencies('flow-bin')).toBe(true);
+    expect(require('../utils').hasDependencies('flow-bin')).toBe(false);
+  });
+
+  it('hasDependencies returns true if a package is in dependencies', () => {
+    mockPkg({ dependencies: { react: '16.8.0' } });
+    expect(require('../utils').hasDevDependencies('react')).toBe(false);
+    expect(require('../utils').hasDependencies('react')).toBe(true);
+  });
+});

--- a/packages/gatsby-theme-dslemay-core/gatsby-config.js
+++ b/packages/gatsby-theme-dslemay-core/gatsby-config.js
@@ -1,3 +1,5 @@
+const { hasDependencies, hasDevDependencies } = require('./utils');
+
 const gaBase = {
   resolve: 'gatsby-plugin-google-analytics',
   options: {
@@ -58,6 +60,10 @@ module.exports = ({ analytics, sitemap } = {}) => {
         ...analytics,
       },
     });
+  }
+
+  if (hasDependencies('flow-bin') || hasDevDependencies('flow-bin')) {
+    plugins.push('gatsby-plugin-flow');
   }
 
   return {

--- a/packages/gatsby-theme-dslemay-core/package.json
+++ b/packages/gatsby-theme-dslemay-core/package.json
@@ -18,13 +18,15 @@
   },
   "dependencies": {
     "gatsby-plugin-compile-es6-packages": "^1.0.6",
+    "gatsby-plugin-flow": "^1.0.4",
     "gatsby-plugin-google-analytics": "^2.0.17",
     "gatsby-plugin-react-helmet": "^3.0.10",
     "gatsby-plugin-sharp": "^2.0.29",
     "gatsby-plugin-sitemap": "^2.0.10",
     "gatsby-source-filesystem": "^2.0.27",
     "gatsby-transformer-sharp": "^2.1.17",
-    "mkdirp": "^0.5.1"
+    "mkdirp": "^0.5.1",
+    "read-pkg-up": "^5.0.0"
   },
   "peerDependencies": {
     "gatsby": "^2.2.2",

--- a/packages/gatsby-theme-dslemay-core/package.json
+++ b/packages/gatsby-theme-dslemay-core/package.json
@@ -17,6 +17,7 @@
     "react-dom": "^16.8.4"
   },
   "dependencies": {
+    "arrify": "^1.0.1",
     "gatsby-plugin-compile-es6-packages": "^1.0.6",
     "gatsby-plugin-flow": "^1.0.4",
     "gatsby-plugin-google-analytics": "^2.0.17",
@@ -25,6 +26,7 @@
     "gatsby-plugin-sitemap": "^2.0.10",
     "gatsby-source-filesystem": "^2.0.27",
     "gatsby-transformer-sharp": "^2.1.17",
+    "lodash.has": "^4.5.2",
     "mkdirp": "^0.5.1",
     "read-pkg-up": "^5.0.0"
   },

--- a/packages/gatsby-theme-dslemay-core/plugin-testing.js
+++ b/packages/gatsby-theme-dslemay-core/plugin-testing.js
@@ -13,4 +13,7 @@ const findPluginObject = pluginName => config => {
   return plugins.find(p => p.resolve === pluginName);
 };
 
-module.exports = findPluginObject;
+const findPluginString = pluginName => config =>
+  config.plugins.includes(pluginName);
+
+module.exports = { findPluginString, findPluginObject };

--- a/packages/gatsby-theme-dslemay-core/utils.js
+++ b/packages/gatsby-theme-dslemay-core/utils.js
@@ -1,0 +1,18 @@
+const arrify = require('arrify');
+const has = require('lodash.has');
+const readPkgUp = require('read-pkg-up');
+
+const { pkg } = readPkgUp.sync();
+
+const hasPkgProp = props => arrify(props).some(prop => has(pkg, prop));
+
+const hasPkgSubProp = pkgProp => props =>
+  hasPkgProp(arrify(props).map(p => `${pkgProp}.${p}`));
+
+const hasDependencies = hasPkgSubProp('dependencies');
+const hasDevDependencies = hasPkgSubProp('devDependencies');
+
+module.exports = {
+  hasDependencies,
+  hasDevDependencies,
+};

--- a/site/package.json
+++ b/site/package.json
@@ -22,6 +22,7 @@
   "scripts": {
     "build": "gatsby build",
     "develop": "gatsby develop",
+    "debug": "node --inspect-brk --no-lazy node_modules/gatsby/dist/bin/gatsby develop",
     "serve": "gatsby serve"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -739,6 +739,14 @@
     js-levenshtein "^1.1.3"
     semver "^5.3.0"
 
+"@babel/preset-flow@^7.0.0-rc.1":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/preset-flow/-/preset-flow-7.0.0.tgz#afd764835d9535ec63d8c7d4caf1c06457263da2"
+  integrity sha512-bJOHrYOPqJZCkPVbG1Lot2r5OSsB+iUOaxiHdlOeB1yPWS6evswVHwvkDLZ54WTaTRIk89ds0iHmGZSnxlPejQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+    "@babel/plugin-transform-flow-strip-types" "^7.0.0"
+
 "@babel/preset-react@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/preset-react/-/preset-react-7.0.0.tgz#e86b4b3d99433c7b3e9e91747e2653958bc6b3c0"
@@ -6305,6 +6313,14 @@ gatsby-plugin-compile-es6-packages@^1.0.6:
   dependencies:
     "@babel/runtime" "^7.0.0"
     regex-escape "^3.4.8"
+
+gatsby-plugin-flow@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-flow/-/gatsby-plugin-flow-1.0.4.tgz#13a93a734115fb595fc725c319c47a007841d94d"
+  integrity sha512-HUFDiZIBEU6ZM6gOytKdX0FtgpZyw3vycZwGdY4Y6rtins9iXrfNmnh0pMyb8jVmCWUlxSPu+LMt14sm1QVDOg==
+  dependencies:
+    "@babel/preset-flow" "^7.0.0-rc.1"
+    "@babel/runtime" "^7.0.0"
 
 gatsby-plugin-google-analytics@^2.0.17:
   version "2.0.17"
@@ -11936,6 +11952,14 @@ read-pkg-up@^4.0.0:
     find-up "^3.0.0"
     read-pkg "^3.0.0"
 
+read-pkg-up@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-5.0.0.tgz#b6a6741cb144ed3610554f40162aa07a6db621b8"
+  integrity sha512-XBQjqOBtTzyol2CpsQOw8LHV0XbDZVG7xMMjmXAJomlVY03WOBRmYgDJETlvcg0H63AJvPRwT7GFi5rvOzUOKg==
+  dependencies:
+    find-up "^3.0.0"
+    read-pkg "^5.0.0"
+
 read-pkg@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-1.1.0.tgz#f5ffaa5ecd29cb31c0474bca7d756b6bb29e3f28"
@@ -11971,6 +11995,14 @@ read-pkg@^4.0.1:
     normalize-package-data "^2.3.2"
     parse-json "^4.0.0"
     pify "^3.0.0"
+
+read-pkg@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-5.0.0.tgz#75449907ece8dfb89cbc76adcba2665316e32b94"
+  integrity sha512-OWufaRc67oJjcgrxckW/qO9q22iYzyiONh8h+GMcnOvSHAmhV1Dr3x+gyRjP+Qxc5jKupkSfoCQLS/98rDPh9A==
+  dependencies:
+    normalize-package-data "^2.3.2"
+    parse-json "^4.0.0"
 
 read@1, read@^1.0.7, read@~1.0.1:
   version "1.0.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9238,6 +9238,11 @@ lodash.get@^4.4.2:
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
 
+lodash.has@^4.5.2:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/lodash.has/-/lodash.has-4.5.2.tgz#d19f4dc1095058cccbe2b0cdf4ee0fe4aa37c862"
+  integrity sha1-0Z9NwQlQWMzL4rDN9O4P5Ko3yGI=
+
 lodash.kebabcase@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.kebabcase/-/lodash.kebabcase-4.1.1.tgz#8489b1cb0d29ff88195cceca448ff6d6cc295c36"


### PR DESCRIPTION
This optionally adds the `gatsby-plugin-flow` plugin if the consuming package has `flow-bin` installed in their dependencies or devDependencies.