### PR TITLE
Feat/add emotion support

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,7 +19,7 @@ module.exports = {
     sourceType: 'module',
   },
   plugins: ['react', 'jest', 'prettier'],
-  extends: ['airbnb', 'prettier', 'prettier/react'],
+  extends: ['airbnb', 'prettier', 'plugin:prettier/recommended', 'prettier/react'],
   rules: {
     'react/jsx-filename-extension': 'off',
     'arrow-parens': ['error', 'as-needed'],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,7 +19,12 @@ module.exports = {
     sourceType: 'module',
   },
   plugins: ['react', 'jest', 'prettier'],
-  extends: ['airbnb', 'prettier', 'plugin:prettier/recommended', 'prettier/react'],
+  extends: [
+    'airbnb',
+    'prettier',
+    'plugin:prettier/recommended',
+    'prettier/react',
+  ],
   rules: {
     'react/jsx-filename-extension': 'off',
     'arrow-parens': ['error', 'as-needed'],

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@commitlint/cli": "^7.5.2",
     "@commitlint/config-conventional": "^7.5.0",
     "babel-eslint": "^10.0.1",
-    "eslint": "^5.15.3",
+    "eslint": "5.15.3",
     "eslint-config-airbnb": "^17.1.0",
     "eslint-config-prettier": "^4.1.0",
     "eslint-plugin-import": "^2.16.0",

--- a/packages/gatsby-theme-dslemay-core/README.md
+++ b/packages/gatsby-theme-dslemay-core/README.md
@@ -68,7 +68,8 @@ Gatsby has a number of plugins which may be added dependening on other dependenc
 
 The installed column indicates whether the config checks for the package in `dependencies`, `devDependencies` or both.
 
-| Dependency | Installed     | Gatsby Plugin            |
-| ---------- | ------------- | ------------------------ |
-| flow-bin   | devDependency | gatsby-plugin-flow       |
-| typescript | devDependency | gatsby-plugin-typescript |
+| Dependency    | Installed     | Version Reqs | Gatsby Plugin            |
+| ------------- | ------------- | ------------ | ------------------------ |
+| flow-bin      | devDependency |              | gatsby-plugin-flow       |
+| typescript    | devDependency |              | gatsby-plugin-typescript |
+| @emotion/core | dependency    | >=10.0.0     | gatsby-plugin-emotion    |

--- a/packages/gatsby-theme-dslemay-core/__tests__/gatsby-config.test.js
+++ b/packages/gatsby-theme-dslemay-core/__tests__/gatsby-config.test.js
@@ -1,5 +1,6 @@
 /* eslint-disable global-require */
 jest.mock('../utils', () => ({
+  ...jest.requireActual('../utils'),
   hasDependencies: jest.fn(() => false),
   hasDevDependencies: jest.fn(() => false),
   get pkg() {
@@ -129,7 +130,7 @@ describe('Gatsby Plugin Emotion', () => {
     mockDeps({ dep: true });
     const utils = require('../utils');
     const spy = jest.spyOn(utils, 'pkg', 'get');
-    spy.mockReturnValueOnce({ dependencies: { emotion: '10.1.0' } });
+    spy.mockReturnValueOnce({ dependencies: { '@emotion/core': '10.1.0' } });
     const config = require('../gatsby-config')();
     expect(hasEmotion(config)).toBe(true);
     spy.mockRestore();
@@ -139,7 +140,7 @@ describe('Gatsby Plugin Emotion', () => {
     mockDeps({ dep: true });
     const utils = require('../utils');
     const spy = jest.spyOn(utils, 'pkg', 'get');
-    spy.mockReturnValueOnce({ dependencies: { emotion: '9.1.0' } });
+    spy.mockReturnValueOnce({ dependencies: { '@emotion/core': '9.1.0' } });
     const config = require('../gatsby-config')();
     expect(hasEmotion(config)).toBe(false);
     spy.mockRestore();

--- a/packages/gatsby-theme-dslemay-core/__tests__/gatsby-config.test.js
+++ b/packages/gatsby-theme-dslemay-core/__tests__/gatsby-config.test.js
@@ -3,7 +3,10 @@ jest.mock('../utils', () => ({
   hasDependencies: jest.fn(() => false),
   hasDevDependencies: jest.fn(() => false),
   get pkg() {
-    return {};
+    return {
+      dependencies: {},
+      devDependencies: {},
+    };
   },
 }));
 const { findPluginString, findPluginObject } = require('../plugin-testing');
@@ -116,5 +119,35 @@ describe('Gatsby Plugin TypeScript', () => {
     mockDeps({ dev: false, dep: false });
     const config = require('../gatsby-config')();
     expect(hasTS(config)).toBe(false);
+  });
+});
+
+describe('Gatsby Plugin Emotion', () => {
+  const hasEmotion = findPluginString('gatsby-plugin-emotion');
+
+  it('adds the plugin if Emotion >= 10 is in the package dependencies', () => {
+    mockDeps({ dep: true });
+    const utils = require('../utils');
+    const spy = jest.spyOn(utils, 'pkg', 'get');
+    spy.mockReturnValueOnce({ dependencies: { emotion: '10.1.0' } });
+    const config = require('../gatsby-config')();
+    expect(hasEmotion(config)).toBe(true);
+    spy.mockRestore();
+  });
+
+  it('does not add the plugin if Emotion < 10 is in the package dependencies', () => {
+    mockDeps({ dep: true });
+    const utils = require('../utils');
+    const spy = jest.spyOn(utils, 'pkg', 'get');
+    spy.mockReturnValueOnce({ dependencies: { emotion: '9.1.0' } });
+    const config = require('../gatsby-config')();
+    expect(hasEmotion(config)).toBe(false);
+    spy.mockRestore();
+  });
+
+  it('does not add the plugin if Emotion is not in the package dependencies', () => {
+    mockDeps({ dep: false });
+    const config = require('../gatsby-config')();
+    expect(hasEmotion(config)).toBe(false);
   });
 });

--- a/packages/gatsby-theme-dslemay-core/gatsby-config.js
+++ b/packages/gatsby-theme-dslemay-core/gatsby-config.js
@@ -1,4 +1,5 @@
-const { hasDevDependencies } = require('./utils');
+const semver = require('semver');
+const { hasDependencies, hasDevDependencies, pkg } = require('./utils');
 
 const gaBase = {
   resolve: 'gatsby-plugin-google-analytics',
@@ -68,6 +69,13 @@ module.exports = ({ analytics, sitemap } = {}) => {
 
   if (hasDevDependencies('typescript')) {
     plugins.push('gatsby-plugin-typescript');
+  }
+
+  if (
+    hasDependencies('emotion') &&
+    semver.clean(pkg.dependencies.emotion).split('.')[0] >= 10
+  ) {
+    plugins.push('gatsby-plugin-emotion');
   }
 
   return {

--- a/packages/gatsby-theme-dslemay-core/gatsby-config.js
+++ b/packages/gatsby-theme-dslemay-core/gatsby-config.js
@@ -1,5 +1,10 @@
 const semver = require('semver');
-const { hasDependencies, hasDevDependencies, pkg } = require('./utils');
+const {
+  hasDependencies,
+  hasDevDependencies,
+  pkg,
+  stripSemverRanges,
+} = require('./utils');
 
 const gaBase = {
   resolve: 'gatsby-plugin-google-analytics',
@@ -72,8 +77,11 @@ module.exports = ({ analytics, sitemap } = {}) => {
   }
 
   if (
-    hasDependencies('emotion') &&
-    semver.clean(pkg.dependencies.emotion).split('.')[0] >= 10
+    hasDependencies('@emotion/core') &&
+    semver.satisfies(
+      stripSemverRanges(pkg.dependencies['@emotion/core']),
+      '>= 10.0.0',
+    )
   ) {
     plugins.push('gatsby-plugin-emotion');
   }

--- a/packages/gatsby-theme-dslemay-core/package.json
+++ b/packages/gatsby-theme-dslemay-core/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "arrify": "^1.0.1",
     "gatsby-plugin-compile-es6-packages": "^1.0.6",
+    "gatsby-plugin-emotion": "^4.0.6",
     "gatsby-plugin-flow": "^1.0.4",
     "gatsby-plugin-google-analytics": "^2.0.17",
     "gatsby-plugin-react-helmet": "^3.0.10",
@@ -29,7 +30,8 @@
     "gatsby-transformer-sharp": "^2.1.17",
     "lodash.has": "^4.5.2",
     "mkdirp": "^0.5.1",
-    "read-pkg-up": "^5.0.0"
+    "read-pkg-up": "^5.0.0",
+    "semver": "^6.0.0"
   },
   "peerDependencies": {
     "gatsby": "^2.2.2",

--- a/packages/gatsby-theme-dslemay-core/utils.js
+++ b/packages/gatsby-theme-dslemay-core/utils.js
@@ -15,4 +15,5 @@ const hasDevDependencies = hasPkgSubProp('devDependencies');
 module.exports = {
   hasDependencies,
   hasDevDependencies,
+  pkg,
 };

--- a/packages/gatsby-theme-dslemay-core/utils.js
+++ b/packages/gatsby-theme-dslemay-core/utils.js
@@ -18,5 +18,5 @@ module.exports = {
   hasDependencies,
   hasDevDependencies,
   pkg,
-  stripSemverRanges
+  stripSemverRanges,
 };

--- a/packages/gatsby-theme-dslemay-core/utils.js
+++ b/packages/gatsby-theme-dslemay-core/utils.js
@@ -12,8 +12,11 @@ const hasPkgSubProp = pkgProp => props =>
 const hasDependencies = hasPkgSubProp('dependencies');
 const hasDevDependencies = hasPkgSubProp('devDependencies');
 
+const stripSemverRanges = range => range.replace(/[>=<^~|]/g, '');
+
 module.exports = {
   hasDependencies,
   hasDevDependencies,
   pkg,
+  stripSemverRanges
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -565,7 +565,7 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-jsx" "^7.2.0"
 
-"@babel/plugin-transform-react-jsx@^7.0.0":
+"@babel/plugin-transform-react-jsx@^7.0.0", "@babel/plugin-transform-react-jsx@^7.1.6":
   version "7.3.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.3.0.tgz#f2cab99026631c767e2745a5368b331cfe8f5290"
   integrity sha512-a/+aRb7R06WcKvQLOu4/TpjKOdvVEKRLWFpKcNuHhiREPgGRB4TQJxq07+EZLS8LFVYpfq1a5lDUnuMdcCpBKg==
@@ -926,6 +926,54 @@
   integrity sha512-oTu185GufTYHjTXPHu6k6HL7iuASOvDOtQizZWRSxj0VXuoki6e0HzvGZsRsycDTOn04Q9hVu+PhF83IUwRpeg==
   dependencies:
     find-up "^2.1.0"
+
+"@emotion/babel-plugin-jsx-pragmatic@^0.1.2":
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/@emotion/babel-plugin-jsx-pragmatic/-/babel-plugin-jsx-pragmatic-0.1.2.tgz#bb98bbef8effe83418307563c34e784deae57a1a"
+  integrity sha512-BapTL0I1flAB+qrfOmltOdLORBtz8dvtKjcHZmYYWdiGsn+2bZxaZDra+S0jDLd1tnhvPvhHoGv3140WR8PAow==
+  dependencies:
+    "@babel/plugin-syntax-jsx" "^7.2.0"
+
+"@emotion/babel-preset-css-prop@^10.0.5":
+  version "10.0.9"
+  resolved "https://registry.yarnpkg.com/@emotion/babel-preset-css-prop/-/babel-preset-css-prop-10.0.9.tgz#70386bd88fe4d8896e1b9729364daf3a6051f726"
+  integrity sha512-fETOWFEe734RlJZTuq6+NeHTzl+Kge4yRm3yrQC+Y2I+KxZjYiU5XUPdbylr0EATbkSzFXgVGKppciZfA5j1mw==
+  dependencies:
+    "@babel/plugin-transform-react-jsx" "^7.1.6"
+    "@emotion/babel-plugin-jsx-pragmatic" "^0.1.2"
+    babel-plugin-emotion "^10.0.9"
+    object-assign "^4.1.1"
+
+"@emotion/hash@0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.7.1.tgz#9833722341379fb7d67f06a4b00ab3c37913da53"
+  integrity sha512-OYpa/Sg+2GDX+jibUfpZVn1YqSVRpYmTLF2eyAfrFTIJSbwyIrc+YscayoykvaOME/wV4BV0Sa0yqdMrgse6mA==
+
+"@emotion/memoize@0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.1.tgz#e93c13942592cf5ef01aa8297444dc192beee52f"
+  integrity sha512-Qv4LTqO11jepd5Qmlp3M1YEjBumoTHcHFdgPTQ+sFlIL5myi/7xu/POwP7IRu6odBdmLXdtIs1D6TuW6kbwbbg==
+
+"@emotion/serialize@^0.11.6":
+  version "0.11.6"
+  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-0.11.6.tgz#78be8b9ee9ff49e0196233ba6ec1c1768ba1e1fc"
+  integrity sha512-n4zVv2qGLmspF99jaEUwnMV0fnEGsyUMsC/8KZKUSUTZMYljHE+j+B6rSD8PIFtaUIhHaxCG2JawN6L+OgLN0Q==
+  dependencies:
+    "@emotion/hash" "0.7.1"
+    "@emotion/memoize" "0.7.1"
+    "@emotion/unitless" "0.7.3"
+    "@emotion/utils" "0.11.1"
+    csstype "^2.5.7"
+
+"@emotion/unitless@0.7.3":
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.3.tgz#6310a047f12d21a1036fb031317219892440416f"
+  integrity sha512-4zAPlpDEh2VwXswwr/t8xGNDGg8RQiPxtxZ3qQEXyQsBV39ptTdESCjuBvGze1nLMVrxmTIKmnO/nAV8Tqjjzg==
+
+"@emotion/utils@0.11.1":
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/@emotion/utils/-/utils-0.11.1.tgz#8529b7412a6eb4b48bdf6e720cc1b8e6e1e17628"
+  integrity sha512-8M3VN0hetwhsJ8dH8VkVy7xo5/1VoBsDOk/T4SJOeXwTO1c4uIqVNx2qyecLFnnUWD5vvUqHQ1gASSeUN6zcTg==
 
 "@gatsbyjs/relay-compiler@2.0.0-printer-fix.2":
   version "2.0.0-printer-fix.2"
@@ -2645,6 +2693,22 @@ babel-plugin-dynamic-import-node@^1.2.0:
   dependencies:
     babel-plugin-syntax-dynamic-import "^6.18.0"
 
+babel-plugin-emotion@^10.0.9:
+  version "10.0.9"
+  resolved "https://registry.yarnpkg.com/babel-plugin-emotion/-/babel-plugin-emotion-10.0.9.tgz#04a0404d5a4084d5296357a393d344c0f8303ae4"
+  integrity sha512-IfWP12e9/wHtWHxVTzD692Nbcmrmcz2tip7acp6YUqtrP7slAyr5B+69hyZ8jd55GsyNSZwryNnmuDEVe0j+7w==
+  dependencies:
+    "@babel/helper-module-imports" "^7.0.0"
+    "@emotion/hash" "0.7.1"
+    "@emotion/memoize" "0.7.1"
+    "@emotion/serialize" "^0.11.6"
+    babel-plugin-macros "^2.0.0"
+    babel-plugin-syntax-jsx "^6.18.0"
+    convert-source-map "^1.5.0"
+    escape-string-regexp "^1.0.5"
+    find-root "^1.1.0"
+    source-map "^0.5.7"
+
 babel-plugin-istanbul@^5.1.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-5.1.1.tgz#7981590f1956d75d67630ba46f0c22493588c893"
@@ -2661,7 +2725,7 @@ babel-plugin-jest-hoist@^24.6.0:
   dependencies:
     "@types/babel__traverse" "^7.0.6"
 
-babel-plugin-macros@^2.4.2:
+babel-plugin-macros@^2.0.0, babel-plugin-macros@^2.4.2:
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/babel-plugin-macros/-/babel-plugin-macros-2.5.1.tgz#4a119ac2c2e19b458c259b9accd7ee34fd57ec6f"
   integrity sha512-xN3KhAxPzsJ6OQTktCanNpIFnnMsCV+t8OloKxIL72D6+SUZYFn9qfklPgef5HyyDtzYZqqb+fs1S12+gQY82Q==
@@ -2679,6 +2743,11 @@ babel-plugin-syntax-dynamic-import@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz#8d6a26229c83745a9982a441051572caa179b1da"
   integrity sha1-jWomIpyDdFqZgqRBBRVyyqF5sdo=
+
+babel-plugin-syntax-jsx@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
+  integrity sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=
 
 babel-plugin-syntax-object-rest-spread@^6.8.0:
   version "6.13.0"
@@ -4011,7 +4080,7 @@ convert-hrtime@^2.0.0:
   resolved "https://registry.yarnpkg.com/convert-hrtime/-/convert-hrtime-2.0.0.tgz#19bfb2c9162f9e11c2f04c2c79de2b7e8095c627"
   integrity sha1-Gb+yyRYvnhHC8Ewsed4rfoCVxic=
 
-convert-source-map@^1.1.0, convert-source-map@^1.4.0:
+convert-source-map@^1.1.0, convert-source-map@^1.4.0, convert-source-map@^1.5.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.6.0.tgz#51b537a8c43e0f04dec1993bffcdd504e758ac20"
   integrity sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==
@@ -4425,7 +4494,7 @@ cssstyle@^1.0.0:
   dependencies:
     cssom "0.3.x"
 
-csstype@^2.2.0:
+csstype@^2.2.0, csstype@^2.5.7:
   version "2.6.3"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.3.tgz#b701e5968245bf9b08d54ac83d00b624e622a9fa"
   integrity sha512-rINUZXOkcBmoHWEyu7JdHu5JMzkGRoMX4ov9830WNgxf5UYxcBUO0QTKAqeJ5EZfSdlrcJYkC8WwfVW7JYi4yg==
@@ -6021,6 +6090,11 @@ find-parent-dir@^0.3.0:
   resolved "https://registry.yarnpkg.com/find-parent-dir/-/find-parent-dir-0.3.0.tgz#33c44b429ab2b2f0646299c5f9f718f376ff8d54"
   integrity sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=
 
+find-root@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/find-root/-/find-root-1.1.0.tgz#abcfc8ba76f708c42a97b3d685b7e9450bfb9ce4"
+  integrity sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng==
+
 find-up@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-1.1.2.tgz#6b2e9822b1a2ce0a60ab64d610eccad53cb24d0f"
@@ -6326,6 +6400,14 @@ gatsby-plugin-compile-es6-packages@^1.0.6:
   dependencies:
     "@babel/runtime" "^7.0.0"
     regex-escape "^3.4.8"
+
+gatsby-plugin-emotion@^4.0.6:
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/gatsby-plugin-emotion/-/gatsby-plugin-emotion-4.0.6.tgz#5f496df66b2640874fcb073e4f2d8a2a1a4632da"
+  integrity sha512-cBCGVdNkULlrYMPsrCVDKrCxiKpZq4PL9n5qzQ538FWmg+XqBhQKWaH8dALwEzoDS5GyHXQy1hI7XHoWmDBJAQ==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    "@emotion/babel-preset-css-prop" "^10.0.5"
 
 gatsby-plugin-flow@^1.0.4:
   version "1.0.4"
@@ -12655,6 +12737,11 @@ semver-truncate@^1.1.2:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.6.0.tgz#7e74256fbaa49c75aa7c7a205cc22799cac80004"
   integrity sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==
+
+semver@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-6.0.0.tgz#05e359ee571e5ad7ed641a6eec1e547ba52dea65"
+  integrity sha512-0UewU+9rFapKFnlbirLi3byoOuhrSsli/z/ihNnvM24vgF+8sNBiI1LZPBSH9wJKUwaUbw+s3hToDLCXkrghrQ==
 
 semver@~5.3.0:
   version "5.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5468,7 +5468,49 @@ eslint-visitor-keys@^1.0.0:
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
   integrity sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==
 
-eslint@^5.15.3, eslint@^5.6.0:
+eslint@5.15.3:
+  version "5.15.3"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.15.3.tgz#c79c3909dc8a7fa3714fb340c11e30fd2526b8b5"
+  integrity sha512-vMGi0PjCHSokZxE0NLp2VneGw5sio7SSiDNgIUn2tC0XkWJRNOIoHIg3CliLVfXnJsiHxGAYrkw0PieAu8+KYQ==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    ajv "^6.9.1"
+    chalk "^2.1.0"
+    cross-spawn "^6.0.5"
+    debug "^4.0.1"
+    doctrine "^3.0.0"
+    eslint-scope "^4.0.3"
+    eslint-utils "^1.3.1"
+    eslint-visitor-keys "^1.0.0"
+    espree "^5.0.1"
+    esquery "^1.0.1"
+    esutils "^2.0.2"
+    file-entry-cache "^5.0.1"
+    functional-red-black-tree "^1.0.1"
+    glob "^7.1.2"
+    globals "^11.7.0"
+    ignore "^4.0.6"
+    import-fresh "^3.0.0"
+    imurmurhash "^0.1.4"
+    inquirer "^6.2.2"
+    js-yaml "^3.12.0"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    levn "^0.3.0"
+    lodash "^4.17.11"
+    minimatch "^3.0.4"
+    mkdirp "^0.5.1"
+    natural-compare "^1.4.0"
+    optionator "^0.8.2"
+    path-is-inside "^1.0.2"
+    progress "^2.0.0"
+    regexpp "^2.0.1"
+    semver "^5.5.1"
+    strip-ansi "^4.0.0"
+    strip-json-comments "^2.0.1"
+    table "^5.2.3"
+    text-table "^0.2.0"
+
+eslint@^5.6.0:
   version "5.16.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-5.16.0.tgz#a1e3ac1aae4a3fbd8296fcf8f7ab7314cbb6abea"
   integrity sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==


### PR DESCRIPTION
Checks if the consuming package has version >= 10.0.0 of `@emotion/core` and adds the `gatsby-plugin-emotion` to the configuration.