### PR TITLE
chore: configure npm files attribute

### DIFF
--- a/packages/gatsby-theme-dslemay-core/package.json
+++ b/packages/gatsby-theme-dslemay-core/package.json
@@ -11,6 +11,12 @@
     "react",
     "tooling"
   ],
+  "files": [
+    "gatsby-config.js",
+    "gatsby-node.js",
+    "utils.js",
+    "index.js"
+  ],
   "devDependencies": {
     "gatsby": "^2.2.2",
     "react": "^16.8.4",


### PR DESCRIPTION
Use files attribute for allow list for package publishing.